### PR TITLE
Add __VA_OPT__(,) on print macro

### DIFF
--- a/lib/unittest.h
+++ b/lib/unittest.h
@@ -43,7 +43,7 @@ extern "C" {
 #define UNITTEST_XSTR(TXT) #TXT
 #define UNITTEST_STR(TXT) UNITTEST_XSTR(TXT)
 
-#define UNITTEST_PRINT(WHAT, ...) fprintf(stdout, WHAT, __VA_ARGS__);
+#define UNITTEST_PRINT(WHAT, ...) fprintf(stdout, WHAT __VA_OPT__(,) __VA_ARGS__);
 #define UNITTEST_FILNUM __FILE__ ":" UNITTEST_STR(__LINE__)
 #define UNITTEST_PRINTARG()
 

--- a/lib/unittest.h
+++ b/lib/unittest.h
@@ -259,13 +259,13 @@ extern "C" {
 /**
 * @brief Create unit test with standarized name
 */
-#define UNITTEST_BEGIN(NAME) int test_##NAME()
+#define UNITTEST_BEGIN(NAME, ...) int test_##NAME(__VA_ARGS__)
 
 /**
  * @brief Unit test forward declaration statement.
  * Should be used in header file containing test declaration, and the actual test should be defined later using UNITTEST_BEGIN macro.
  */
-#define UNITTEST_DECLARE(NAME) UNITTEST_BEGIN(NAME)
+#define UNITTEST_DECLARE(NAME, ...) UNITTEST_BEGIN(NAME __VA_OPT__(,) __VA_ARGS__)
 
 /**
 * @brief Finish unit test and display test results.
@@ -285,7 +285,7 @@ extern "C" {
 /**
 * @brief Execute unit test - this must be executed in unit test RUNBLOCK
 */
-#define UNITTEST_EXEC(NAME) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(); } while(0)
+#define UNITTEST_EXEC(NAME, ...) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) __VA_OPT__("(") #__VA_ARGS__ __VA_OPT__(")") "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(__VA_ARGS__); } while(0)
 
 /**
 * @brief Finish unit test execution block and display test results.

--- a/lib/unittest.h
+++ b/lib/unittest.h
@@ -259,13 +259,23 @@ extern "C" {
 /**
 * @brief Create unit test with standarized name
 */
-#define UNITTEST_BEGIN(NAME, ...) int test_##NAME(__VA_ARGS__)
+#define UNITTEST_BEGIN(NAME) int test_##NAME()
+
+/**
+* @brief Create paramemeterized unit test with standarized name
+*/
+#define UNITTEST_BEGIN_P(NAME, ...) int test_##NAME(__VA_ARGS__)
 
 /**
  * @brief Unit test forward declaration statement.
  * Should be used in header file containing test declaration, and the actual test should be defined later using UNITTEST_BEGIN macro.
  */
-#define UNITTEST_DECLARE(NAME, ...) UNITTEST_BEGIN(NAME __VA_OPT__(,) __VA_ARGS__)
+#define UNITTEST_DECLARE(NAME) UNITTEST_BEGIN(NAME)
+
+/**
+ * @brief Parameterized unit test forward declaration statement.
+ * Should be used in header file containing test declaration, and the actual test should be defined later using UNITTEST_BEGIN_P macro.
+ */
 
 /**
 * @brief Finish unit test and display test results.
@@ -285,7 +295,12 @@ extern "C" {
 /**
 * @brief Execute unit test - this must be executed in unit test RUNBLOCK
 */
-#define UNITTEST_EXEC(NAME, ...) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) __VA_OPT__("(") #__VA_ARGS__ __VA_OPT__(")") "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(__VA_ARGS__); } while(0)
+#define UNITTEST_EXEC(NAME) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(); } while(0)
+
+/**
+* @brief Execute parameterized unit test - this must be executed in unit test RUNBLOCK
+*/
+#define UNITTEST_EXEC(NAME, ...) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) __VA_OPT__("(") #__VA_ARGS __VA_OPT__(")") "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(__VA_ARGS__); } while(0)
 
 /**
 * @brief Finish unit test execution block and display test results.

--- a/lib/unittest.h
+++ b/lib/unittest.h
@@ -276,6 +276,7 @@ extern "C" {
  * @brief Parameterized unit test forward declaration statement.
  * Should be used in header file containing test declaration, and the actual test should be defined later using UNITTEST_BEGIN_P macro.
  */
+#define UNITTEST_DECLARE_P(NAME, ...) UNITTEST_BEGIN(NAME __VA_OPT__(,) __VA_ARGS__)
 
 /**
 * @brief Finish unit test and display test results.
@@ -300,7 +301,7 @@ extern "C" {
 /**
 * @brief Execute parameterized unit test - this must be executed in unit test RUNBLOCK
 */
-#define UNITTEST_EXEC(NAME, ...) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) __VA_OPT__("(") #__VA_ARGS __VA_OPT__(")") "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(__VA_ARGS__); } while(0)
+#define UNITTEST_EXEC_P(NAME, ...) do { UNITTEST_PRINT("Running test \"" UNITTEST_STR(NAME) __VA_OPT__("(") #__VA_ARGS __VA_OPT__(")") "\"\r\n") ++unittest_all; unittest_passed += test_##NAME(__VA_ARGS__); } while(0)
 
 /**
 * @brief Finish unit test execution block and display test results.


### PR DESCRIPTION
Hey mate, was trying to use this project and encountered this problem:

If the `__VA_ARGS__` is empty, the _trailing_ comma will be a problem. The `__VA_OPT__(,)` should solve this.

I'm creating as a draft in case I find some other suggestions while I'm using this.

Cheers